### PR TITLE
Fix(iOS): Fix RN bundle name

### DIFF
--- a/ios/ghubber/AppDelegate.m
+++ b/ios/ghubber/AppDelegate.m
@@ -31,7 +31,7 @@
 {
   NSURL *jsCodeLocation;
 
-  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"ghubber"
                                                initialProperties:nil


### PR DESCRIPTION
I didn't find an official document, but it works. Is it possible no one have tested this project in iOS since RN 0.49?

Similar change can be seen in https://github.com/gitpoint/git-point/pull/698/files#diff-af3d940dcb00513dd25cdba83501bd1aR24.